### PR TITLE
Return error instead exit at input invalid service name

### DIFF
--- a/ipcimpl/sm.cpp
+++ b/ipcimpl/sm.cpp
@@ -6,13 +6,21 @@ partial SmService {
 }
 */
 
+static bool smInitialized = false;
+
 uint32_t SmService::Initialize() {
+	smInitialized = true;
 	return 0;
 }
 
 #define SERVICE(str, iface) do { if(name == (str)) { svc = buildInterface(iface); return 0; } } while(0)
 
 uint32_t SmService::GetService(IN ServiceName _name, OUT shared_ptr<IPipe>& svc) {
+	if(!smInitialized) {
+		// FIXME: libtransistor need to impl ::Initialize
+		// return 0x415;
+	}
+
 	string name((char *) _name, strnlen((char *) _name, 8));
 	
 	if(ports.find(name) != ports.end()) {
@@ -22,7 +30,8 @@ uint32_t SmService::GetService(IN ServiceName _name, OUT shared_ptr<IPipe>& svc)
 	}
 	SERVICE_MAPPING();
 
-	LOG_ERROR(Sm, "Unknown service name %s", name.c_str());
+	LOG_DEBUG(Sm, "Unknown service name %s", name.c_str());
+	return 0xC15;
 }
 
 uint32_t SmService::RegisterService(IN ServiceName _name, OUT shared_ptr<NPort>& port) {


### PR DESCRIPTION
This patch resupport libnx.

libnx will pass intentionally wrong input on `smInitialize` API
for checking sm initialized information.

but libtransistor not yet implemented this checking.

https://github.com/switchbrew/libnx/blob/3926969/nx/source/services/sm.c#L16