### PR TITLE
Add alternate file of byteswap.h for macOS

### DIFF
--- a/Ctu.h
+++ b/Ctu.h
@@ -1,6 +1,10 @@
 #pragma once
 
-#include <byteswap.h>
+#if defined(__APPLE__)
+	#include <libkern/OSByteOrder.h>
+#else
+	#include <byteswap.h>
+#endif
 #include <netinet/in.h>
 #include <stdint.h>
 #include <string.h>
@@ -52,10 +56,10 @@ const gptr TERMADDR = 1ULL << 61;
 #define LONGFMT "%lx"
 
 enum LogLevel {
-	None = 0, 
-	Error = 1, 
-	Warn = 2, 
-	Debug = 3, 
+	None = 0,
+	Error = 1,
+	Warn = 2,
+	Debug = 3,
 	Info = 4
 };
 
@@ -164,7 +168,7 @@ public:
 	gptr loadbase, loadsize;
 
 	bool socketsEnabled;
-	
+
 private:
 	ghandle handleId;
 	unordered_map<ghandle, shared_ptr<KObject>> handles;


### PR DESCRIPTION
In Mac OS, byteswap.h does not exist.
Instead, We must use OSByteOrder.h.