### PR TITLE
Make SleepThread yield execution to other threads

### DIFF
--- a/Svc.cpp
+++ b/Svc.cpp
@@ -211,6 +211,12 @@ void Svc::ExitThread() {
 
 guint Svc::SleepThread(guint ns) {
 	LOG_DEBUG(Svc[0x0B], "SleepThread 0x" LONGFMT " ns", ns);
+
+	auto thread = ctu->tm.current();
+	// Yield, at least.
+	thread->suspend([=] {
+		thread->resume([=] {});
+	});
 	return 0;
 }
 


### PR DESCRIPTION
This aligns its behavior to be a bit closer than what's expected. It is necessary for some pthread unit test relying on sleep actually sleeping (which it still isn't, but at least it's a bit closer 🤷‍♂️)