### PR TITLE
Added ipcimpl for am and hid.

### DIFF
--- a/ipcimpl/am.cpp
+++ b/ipcimpl/am.cpp
@@ -1,0 +1,23 @@
+#include "Ctu.h"
+
+uint32_t nn::am::service::ICommonStateGetter::GetEventHandle(OUT shared_ptr<KObject>& _0) {
+	shared_ptr<Waitable> waitobj = make_shared<Waitable>();
+        waitobj->signal(0);
+        _0 = waitobj;
+	return 0;
+}
+
+uint32_t nn::am::service::ICommonStateGetter::ReceiveMessage(OUT nn::am::AppletMessage& _0) {
+	_0 = 0xF;
+	return 0;
+}
+
+uint32_t nn::am::service::ICommonStateGetter::GetCurrentFocusState(OUT uint8_t& _0) {
+	_0 = 1;
+	return 0;
+}
+
+uint32_t nn::am::service::IWindowController::GetAppletResourceUserId(OUT nn::applet::AppletResourceUserId& _0) {
+	_0 = 1;
+	return 0;
+}

--- a/ipcimpl/hid.cpp
+++ b/ipcimpl/hid.cpp
@@ -1,0 +1,6 @@
+#include "Ctu.h"
+
+uint32_t nn::hid::IAppletResource::GetSharedMemoryHandle(OUT shared_ptr<KObject>& _0) {
+	_0 = make_shared<MemoryBlock>(0x40000, 0x1);
+	return 0;
+}


### PR DESCRIPTION
Added implementation for AM and HID. Official apps/{latest libnx} no longer break during AM init. HID init also now works properly with libnx.