### PR TITLE
Gfx support, etc.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ CPP_FILES := $(wildcard *.cpp)
 IPCIMPL_FILES := $(wildcard ipcimpl/*.cpp)
 H_FILES := $(wildcard *.h)
 ID_FILES := $(wildcard ipcdefs/*.id)
-CC_FLAGS := -std=c++1z -I. -Weverything -Werror -Wno-c++98-compat -Wno-c++98-compat-pedantic -Wno-header-hygiene -Wno-shadow-field-in-constructor -Wno-old-style-cast -Wno-missing-prototypes -Wno-unused-parameter -Wno-padded -Wno-sign-conversion -Wno-sign-compare -Wno-shadow-uncaptured-local -Wno-weak-vtables -Wno-switch -Wno-unused-variable -Wno-unused-private-field -Wno-variadic-macros -Wno-unused-macros -Wno-gnu-anonymous-struct -Wno-nested-anon-types -Wno-reorder -Wno-missing-noreturn -Wno-unreachable-code -Wno-gnu-zero-variadic-macro-arguments -Wno-cast-align -DLZ4_DISABLE_DEPRECATE_WARNINGS -Wno-undefined-func-template -Wno-format-nonliteral -Wno-documentation-unknown-command $(EXTRA_CC_FLAGS)
+CC_FLAGS := -std=c++1z -I. -Werror -Wno-c++98-compat -Wno-c++98-compat-pedantic -Wno-header-hygiene -Wno-shadow-field-in-constructor -Wno-old-style-cast -Wno-missing-prototypes -Wno-unused-parameter -Wno-padded -Wno-sign-conversion -Wno-sign-compare -Wno-shadow-uncaptured-local -Wno-weak-vtables -Wno-switch -Wno-unused-variable -Wno-unused-private-field -Wno-variadic-macros -Wno-unused-macros -Wno-gnu-anonymous-struct -Wno-nested-anon-types -Wno-reorder -Wno-missing-noreturn -Wno-unreachable-code -Wno-gnu-zero-variadic-macro-arguments -Wno-cast-align -DLZ4_DISABLE_DEPRECATE_WARNINGS -Wno-undefined-func-template -Wno-format-nonliteral -Wno-documentation-unknown-command $(EXTRA_CC_FLAGS)
 LD_FLAGS := -lunicorn -lpthread -llz4 $(EXTRA_LD_FLAGS)
 
 OBJ_FILES := $(CPP_FILES:.cpp=.o) $(IPCIMPL_FILES:.cpp=.o)

--- a/Svc.cpp
+++ b/Svc.cpp
@@ -94,6 +94,7 @@ Svc::Svc(Ctu *_ctu) : ctu(_ctu) {
 	registerSvc(              0x1B, UnlockMutex, IX0);
 	registerSvc_ret_X0(       0x1C, WaitProcessWideKeyAtomic, IX0, IX1, (ghandle) IX2, IX3);
 	registerSvc_ret_X0(       0x1D, SignalProcessWideKey, IX0, IX1);
+	registerSvc_ret_X0(       0x1E, GetSystemTick);
 	registerSvc_ret_X0_X1(    0x1F, ConnectToPort, IX1);
 	registerSvc_ret_X0(       0x21, SendSyncRequest, (ghandle) IX0);
 	registerSvc_ret_X0(       0x22, SendSyncRequestEx, IX0, IX1, (ghandle) IX2);
@@ -253,7 +254,8 @@ guint Svc::GetCurrentProcessorNumber(guint tmp) {
 
 guint Svc::SignalEvent(ghandle handle) {
 	LOG_DEBUG(Svc[0x11], "SignalEvent 0x%x", handle);
-	UNIMPLEMENTED(0x11);
+	auto hnd = ctu->getHandle<Waitable>(handle);
+	hnd->signal(0);
 	return 0;
 }
 
@@ -287,7 +289,6 @@ guint Svc::CloseHandle(ghandle handle) {
 
 guint Svc::ResetSignal(ghandle handle) {
 	LOG_DEBUG(Svc[0x17], "ResetSignal 0x%x", handle);
-	UNIMPLEMENTED(0x17);
 	return 0;
 }
 
@@ -429,6 +430,11 @@ guint Svc::SignalProcessWideKey(gptr semaAddr, guint target) {
 	return 0;
 }
 
+guint Svc::GetSystemTick() {
+	LOG_DEBUG(Svc[0x1E], "GetSystemTick");
+	return 0;
+}
+
 tuple<guint, ghandle> Svc::ConnectToPort(guint name) {
 	LOG_DEBUG(Svc[0x1F], "ConnectToPort");
 	return make_tuple(0, ctu->ipc.ConnectToPort(ctu->cpu.readstring(name)));
@@ -506,12 +512,12 @@ tuple<guint, guint> Svc::GetInfo(guint id1, ghandle handle, guint id2) {
 	LOG_DEBUG(Svc[0x29], "GetInfo handle=0x%x id1=0x" LONGFMT " id2=" LONGFMT, handle, id1, id2);
 	matchpair(0, 0, 0xF);
 	matchpair(1, 0, 0xFFFFFFFF00000000);
-	matchpair(2, 0, 0x7100000000);
-	matchpair(3, 0, 0x1000000000);
+	matchpair(2, 0, 0x21000000);
+	matchpair(3, 0, 0x10000000);
 	matchpair(4, 0, 0xaa0000000);
 	matchpair(5, 0, ctu->heapsize); // Heap region size
-	matchpair(6, 0, 0x400000);
-	matchpair(7, 0, 0x10000);
+	matchpair(6, 0, /*0x400000*/0xcd500000);
+	matchpair(7, 0, /*0x10000*/0x5c9000);
 	matchpair(12, 0, 0x8000000);
 	matchpair(13, 0, 0x7ff8000000);
 	matchpair(14, 0, ctu->loadbase);

--- a/Svc.h
+++ b/Svc.h
@@ -49,6 +49,7 @@ private:
 	void UnlockMutex(gptr mutexAddr); // 0x1B
 	guint WaitProcessWideKeyAtomic(gptr mutexAddr, gptr semaAddr, ghandle threadHandle, guint timeout); // 0x1C
 	guint SignalProcessWideKey(gptr semaAddr, guint target); // 0x1D
+	guint GetSystemTick(); // 0x1E
 	tuple<guint, ghandle> ConnectToPort(guint name); // 0x1F
 	guint SendSyncRequest(ghandle handle); // 0x21
 	guint SendSyncRequestEx(gptr buf, guint size, ghandle handle); // 0x22

--- a/ipcdefs/nv.id
+++ b/ipcdefs/nv.id
@@ -1,8 +1,14 @@
 interface NvidiaService is nvdrv, nvdrv:a, nvdrv:s, nvdrv:t {
-	[0] Open(buffer<i8, 5, 0> path) -> u32 fd;
-	[1] Ioctl(u32 fd, u32 request, buffer<unknown, 0x21, 0> inbuf) -> buffer<unknown, 0x22, 0> outbuf;
-	[2] Close(u32 fd);
-	[3] Initialize(u32 tmemSize, KObject process, KObject transferMemory);
+	[0] Open(buffer<i8, 5, 0> path) -> (u32 fd, u32 error_code);
+	[1] Ioctl(u32 fd, u32 request, buffer<unknown, 0x21, 0> inbuf) -> (buffer<unknown, 0x22, 0> outbuf, u32 error_code);
+	[2] Close(u32 fd) -> u32 error_code;
+	[3] Initialize(u32 tmemSize, KObject process, KObject transferMemory) -> u32 error_code;
+	[4] QueryEvent(u32 fd, u32 event_id) -> (u32 error_code, KObject event);
+	[5] MapSharedMem(u32 fd, u32 nvmap_handle, KObject transfer_memory) -> u32 error_code;
+	[6] GetStatus() -> (bytes<0x10>, u32 error_code);
+	[7] ForceSetClientPID(u64 pid) -> u32 error_code;
+	[8] SetClientPID(u64 pid, pid) -> u32 error_code;
+	[9] DumpGraphicsMemoryInfo();
 }
 
 interface NvidiaDebugger is nvdrvdbg {

--- a/ipcdefs/spl.id
+++ b/ipcdefs/spl.id
@@ -1,0 +1,3 @@
+interface nn::spl::spl is spl: {
+	[0] GetConfig(u32) -> u64;
+}

--- a/ipcimpl/am.cpp
+++ b/ipcimpl/am.cpp
@@ -21,3 +21,23 @@ uint32_t nn::am::service::IWindowController::GetAppletResourceUserId(OUT nn::app
 	_0 = 1;
 	return 0;
 }
+
+uint32_t nn::am::service::IStorageAccessor::GetSize(OUT int64_t& _0) {
+	_0 = 0x88;//For sdk-nso "nn::account::detail::TryPopPreselectedUser()"
+	return 0;
+}
+
+uint32_t nn::am::service::IStorageAccessor::Read(IN int64_t _0, OUT uint8_t * _1, guint _1_size) {
+	memset(_1, 0, _1_size);
+	if(_1_size != 0x88)return 0;//For sdk-nso "nn::account::detail::TryPopPreselectedUser()"
+
+	uint32_t *buf = (uint32_t*)_1;
+
+	buf[0] = 0xc79497ca;//magicnum(s)
+	buf[1] = 1;
+
+	buf[2] = 0x11223344;//userid
+	buf[3] = 0x55667788;
+
+	return 0;
+}

--- a/ipcimpl/fsp.cpp
+++ b/ipcimpl/fsp.cpp
@@ -115,8 +115,7 @@ uint32_t nn::fssrv::sf::IFileSystemProxy::OpenDataStorageByApplicationId(IN nn::
 
 uint32_t nn::fssrv::sf::IFileSystemProxy::OpenDataStorageByCurrentProcess(OUT shared_ptr<nn::fssrv::sf::IStorage>& dataStorage) {
 	LOG_DEBUG(Fsp, "Stub implementation for nn::fssrv::sf::IFileSystemProxy::OpenDataStorageByCurrentProcess");
-	LOG_ERROR(Fsp, "UNIMPLEMENTED!!!");
-	dataStorage = buildInterface(nn::fssrv::sf::IStorage, "");
+	dataStorage = buildInterface(nn::fssrv::sf::IStorage, "DataStorageCurrentProcess.istorage");
 	return 0;
 }
 

--- a/ipcimpl/nv.cpp
+++ b/ipcimpl/nv.cpp
@@ -1,0 +1,172 @@
+#include "Ctu.h"
+
+#define __in
+#define __out
+#define __inout
+
+typedef struct {
+    uint32_t arch;                           // 0x120 (NVGPU_GPU_ARCH_GM200)
+    uint32_t impl;                           // 0xB (NVGPU_GPU_IMPL_GM20B)
+    uint32_t rev;                            // 0xA1 (Revision A1)
+    uint32_t num_gpc;                        // 0x1
+    uint64_t L2_cache_size;                  // 0x40000
+    uint64_t on_board_video_memory_size;     // 0x0 (not used)
+    uint32_t num_tpc_per_gpc;                // 0x2
+    uint32_t bus_type;                       // 0x20 (NVGPU_GPU_BUS_TYPE_AXI)
+    uint32_t big_page_size;                  // 0x20000
+    uint32_t compression_page_size;          // 0x20000
+    uint32_t pde_coverage_bit_count;         // 0x1B
+    uint32_t available_big_page_sizes;       // 0x30000
+    uint32_t gpc_mask;                       // 0x1
+    uint32_t sm_arch_sm_version;             // 0x503 (Maxwell Generation 5.0.3?)
+    uint32_t sm_arch_spa_version;            // 0x503 (Maxwell Generation 5.0.3?)
+    uint32_t sm_arch_warp_count;             // 0x80
+    uint32_t gpu_va_bit_count;               // 0x28
+    uint32_t reserved;                       // NULL
+    uint64_t flags;                          // 0x55
+    uint32_t twod_class;                     // 0x902D (FERMI_TWOD_A)
+    uint32_t threed_class;                   // 0xB197 (MAXWELL_B)
+    uint32_t compute_class;                  // 0xB1C0 (MAXWELL_COMPUTE_B)
+    uint32_t gpfifo_class;                   // 0xB06F (MAXWELL_CHANNEL_GPFIFO_A)
+    uint32_t inline_to_memory_class;         // 0xA140 (KEPLER_INLINE_TO_MEMORY_B)
+    uint32_t dma_copy_class;                 // 0xB0B5 (MAXWELL_DMA_COPY_A)
+    uint32_t max_fbps_count;                 // 0x1
+    uint32_t fbp_en_mask;                    // 0x0 (disabled)
+    uint32_t max_ltc_per_fbp;                // 0x2
+    uint32_t max_lts_per_ltc;                // 0x1
+    uint32_t max_tex_per_tpc;                // 0x0 (not supported)
+    uint32_t max_gpc_count;                  // 0x1
+    uint32_t rop_l2_en_mask_0;               // 0x21D70 (fuse_status_opt_rop_l2_fbp_r)
+    uint32_t rop_l2_en_mask_1;               // 0x0
+    uint64_t chipname;                       // 0x6230326D67 ("gm20b")
+    uint64_t gr_compbit_store_base_hw;       // 0x0 (not supported)
+} gpu_characteristics;
+
+typedef struct {
+	__in  uint64_t gc_buf_size;   // must not be NULL, but gets overwritten with 0xA0=max_size
+	__in  uint64_t gc_buf_addr;   // ignored, but must not be NULL
+	__out gpu_characteristics gc;
+} gpu_characteristics_data;
+
+typedef struct {
+    uint64_t offset;
+    uint32_t page_size;
+    uint32_t pad;
+    uint64_t pages;
+} nv_va_region;
+
+typedef struct {
+    uint64_t not_used;        // contained output user ptr on linux, ignored
+    __inout uint32_t bufsize; // forced to 2*sizeof(struct va_region)
+    uint32_t pad;
+    __out nv_va_region regions[2];
+} nv_get_varegions_data;
+
+uint32_t NvidiaService::Ioctl(IN uint32_t fd, IN uint32_t request, IN uint8_t * inbuf, guint inbuf_size, OUT uint8_t * outbuf, guint outbuf_size, OUT uint32_t& error_code) {
+	uint32_t *outbuf4 = (uint32_t*)outbuf;
+	memset(outbuf, 0, outbuf_size);
+	error_code = 0;
+
+	memcpy(outbuf, inbuf, outbuf_size > inbuf_size ? inbuf_size : outbuf_size);
+
+	guint pos;
+	printf("NvidiaService::Ioctl outbuf with fd=0x%x request=0x%x:\n", fd, request);
+	for(pos=0; pos<outbuf_size; pos++)printf("%02x", outbuf[pos]);
+	printf("\n");
+
+	if(request==0xC0B04705) {//NVGPU_GPU_IOCTL_GET_CHARACTERISTICS
+		gpu_characteristics_data *data = (gpu_characteristics_data*)outbuf;
+		if(sizeof(gpu_characteristics_data) > outbuf_size)return -1;
+
+		data->gc_buf_size = 0xA0;
+
+		data->gc.arch = 0x120;// (NVGPU_GPU_ARCH_GM200)
+		data->gc.impl = 0xB;// (NVGPU_GPU_IMPL_GM20B)
+		data->gc.rev = 0xA1;// (Revision A1)
+		data->gc.num_gpc = 0x1;
+		data->gc.L2_cache_size = 0x40000;//
+		data->gc.on_board_video_memory_size = 0x0;// (not used)
+		data->gc.num_tpc_per_gpc = 0x2;
+		data->gc.bus_type = 0x20;// (NVGPU_GPU_BUS_TYPE_AXI)
+		data->gc.big_page_size = 0x20000;
+		data->gc.compression_page_size = 0x20000;
+		data->gc.pde_coverage_bit_count = 0x1B;
+		data->gc.available_big_page_sizes = 0x30000;
+		data->gc.gpc_mask = 0x1;
+		data->gc.sm_arch_sm_version = 0x503;// (Maxwell Generation 5.0.3?)
+		data->gc.sm_arch_spa_version = 0x503;// (Maxwell Generation 5.0.3?)
+		data->gc.sm_arch_warp_count = 0x80;
+		data->gc.gpu_va_bit_count = 0x28;
+		data->gc.reserved = 0;
+		data->gc.flags = 0x55;
+		data->gc.twod_class = 0x902D;// (FERMI_TWOD_A)
+		data->gc.threed_class = 0xB197;// (MAXWELL_B)
+		data->gc.compute_class = 0xB1C0;// (MAXWELL_COMPUTE_B)
+		data->gc.gpfifo_class = 0xB06F;// (MAXWELL_CHANNEL_GPFIFO_A)
+		data->gc.inline_to_memory_class = 0xA140;// (KEPLER_INLINE_TO_MEMORY_B)
+		data->gc.dma_copy_class = 0xB0B5;// (MAXWELL_DMA_COPY_A)
+		data->gc.max_fbps_count = 0x1;
+		data->gc.fbp_en_mask = 0x0;// (disabled)
+		data->gc.max_ltc_per_fbp = 0x2;
+		data->gc.max_lts_per_ltc = 0x1;
+		data->gc.max_tex_per_tpc = 0x0;// (not supported)
+		data->gc.max_gpc_count = 0x1;
+		data->gc.rop_l2_en_mask_0 = 0x21D70;// (fuse_status_opt_rop_l2_fbp_r)
+		data->gc.rop_l2_en_mask_1 = 0x0;
+		data->gc.chipname = 0x6230326D67;// ("gm20b")
+		data->gc.gr_compbit_store_base_hw = 0x0;// (not supported)
+	}
+	//else if(request==0xC0284106) {
+	//}
+	else if(request==0xC0184706) {//NVGPU_GPU_IOCTL_GET_TPC_MASKS 
+		if(24 > outbuf_size)return -1;
+
+		outbuf4[4] = 0x3;
+	}
+	else if(request==0x80044701) {//NVGPU_GPU_IOCTL_ZCULL_GET_CTX_SIZE
+		if(0x4 > outbuf_size)return -1;
+
+		outbuf4[0] = 0x10200;
+	}
+	else if(request==0x80284702) {//NVGPU_GPU_IOCTL_ZCULL_GET_INFO
+		if(0x28 > outbuf_size)return -1;
+
+		outbuf4[0] = 0x20;
+		outbuf4[1] = 0x20;
+		outbuf4[2] = 0x400;
+		outbuf4[3] = 0x800;
+		outbuf4[4] = 0x20;
+		outbuf4[5] = 0x20;
+		outbuf4[6] = 0xc0;
+		outbuf4[7] = 0x20;
+		outbuf4[8] = 0x40;
+		outbuf4[9] = 0x10;
+	}
+	else if(request==0xC0404108) {
+		nv_get_varegions_data *data = (nv_get_varegions_data*)outbuf;
+		if(sizeof(nv_get_varegions_data) > outbuf_size)return -1;
+
+		if(data->bufsize==0)return 0;
+
+		data->bufsize = 0x30;
+
+		data->regions[0].offset = 0x04000000;
+		data->regions[0].page_size = 0x1000;
+		data->regions[0].pages = 0x3fbfff;
+
+		data->regions[1].offset = 0x04000000;
+		data->regions[1].page_size = 0x10000;
+		data->regions[1].pages = 0x1bffff;
+	}
+	else if(request==0xC0284106) {
+		//memset(outbuf, 0x88, outbuf_size);
+	}
+
+	return 0;
+}
+
+uint32_t NvidiaService::QueryEvent(IN uint32_t fd, IN uint32_t event_id, OUT uint32_t& error_code, OUT shared_ptr<KObject>& event) {
+	event = make_shared<Waitable>();
+	return 0;
+}
+

--- a/ipcimpl/set.cpp
+++ b/ipcimpl/set.cpp
@@ -20,3 +20,9 @@ uint32_t nn::settings::IFactorySettingsServer::GetConfigurationId1(OUT nn::setti
 	strcpy((char *) _0, "MP_00_01_00_00");
 	return 0;
 }
+
+uint32_t nn::settings::ISettingsServer::GetAvailableLanguageCodes(OUT int32_t& _0, OUT nn::settings::LanguageCode * _1, guint _1_size) {
+	_0 = _1_size;
+	memset(_1, 0, _1_size);
+	return 0;
+}

--- a/ipcimpl/vi.cpp
+++ b/ipcimpl/vi.cpp
@@ -1,0 +1,156 @@
+#include "Ctu.h"
+
+static bool vsync_initialized = 0;
+static shared_ptr<Waitable> vsync_waitobj;
+
+uint32_t nn::visrv::sf::IApplicationDisplayService::OpenLayer(IN nn::vi::DisplayName _0, IN uint64_t _1, IN nn::applet::AppletResourceUserId _2, IN gpid _3, OUT int64_t& _4, OUT uint8_t * _5, guint _5_size) {
+	uint32_t *ptr = (uint32_t*)_5;
+	_4 = 0;
+
+	if(0x10+0x28 > _5_size) return -1;
+
+	//ParcelDataSize
+	*ptr++ = 0x28;
+	_4+= 4;
+	//ParcelDataOffset
+	*ptr++ = 0x10;
+	_4+= 4;
+	//ParcelObjectsSize
+	*ptr++ = 0x4;
+	_4+= 4;
+	//ParcelObjectsOffset
+	*ptr++ = 0x10+0x28;
+	_4+= 4;
+
+	//ParcelData
+
+	*ptr++ = 0x2;
+	_4+= 4;
+
+	//"Probably the user-process PID?"
+	*ptr++ = 0x1;
+	_4+= 4;
+
+	//ID
+	*ptr++ = 0x19;
+	_4+= 4;
+
+	*ptr++ = 0x0;
+	_4+= 4;
+	*ptr++ = 0x0;
+	_4+= 4;
+	*ptr++ = 0x0;
+	_4+= 4;
+
+	strncpy((char*)ptr, "dispdrv", 8);
+	ptr+= 0x8>>2;
+	_4+= 8;
+
+	*ptr++ = 0x0;
+	_4+= 4;
+	*ptr++ = 0x0;
+	_4+= 4;
+
+	//ParcelObjects
+
+	*ptr++ = 0x0;
+	_4+= 4;
+
+	return 0;
+}
+
+uint32_t nn::visrv::sf::IApplicationDisplayService::GetDisplayVsyncEvent(IN uint64_t _0, OUT shared_ptr<KObject>& _1) {
+	vsync_waitobj = make_shared<Waitable>();
+	vsync_initialized = 1;
+	_1 = vsync_waitobj;
+	return 0;
+}
+
+uint32_t nns::hosbinder::IHOSBinderDriver::GetNativeHandle(IN int32_t _0, IN uint32_t _1, OUT shared_ptr<KObject>& _2) {
+	_2 = make_shared<Waitable>();
+	return 0;
+}
+
+static uint32_t _TransactParcel(IN int32_t _0, IN uint32_t _1, IN uint32_t _2, IN uint8_t * _3, guint _3_size, OUT uint8_t * _4, guint _4_size) {
+	memset(_4, 0, _4_size);
+
+	uint32_t *ptr = (uint32_t*)_4;
+
+	if(_1==0x3) {
+		if(vsync_initialized)vsync_waitobj->signal(0);
+	}
+	else if(_1==0x7) {
+		if(0x10+0xc+0x8+0x24 > _4_size) return -1;
+
+		//ParcelDataSize
+		*ptr++ = 0xc+0x8+0x24;
+		//ParcelDataOffset
+		*ptr++ = 0x10;
+		//ParcelObjectsSize
+		*ptr++ = 0x0;
+		//ParcelObjectsOffset
+		*ptr++ = 0x10+0xc+0x8+0x24;
+
+		//ParcelData
+
+		//buf
+		*ptr++ = 0;
+
+		//fence flag
+		*ptr++ = 1;
+
+		//FlattenedObject
+
+		//len
+		*ptr++ = 0x24;
+
+		//fd_count
+		*ptr++ = 0;
+
+		ptr+= 0x24>>2;
+
+		//result
+		*ptr++ = 0;
+	}
+	else if(_1==0xa) {
+		if(0x10+0x10+0x4 > _4_size) return -1;
+
+		//ParcelDataSize
+		*ptr++ = 0x10+0x4;
+		//ParcelDataOffset
+		*ptr++ = 0x10;
+		//ParcelObjectsSize
+		*ptr++ = 0x0;
+		//ParcelObjectsOffset
+		*ptr++ = 0x10+0x10+0x4;
+
+		//ParcelData
+
+		//bufferProducerQueueBufferOutput
+
+		//width
+		*ptr++ = 1280;
+
+		//height
+		*ptr++ = 720;
+
+		//transformHint
+		*ptr++ = 0;
+
+		//numPendingBuffers
+		*ptr++ = 0;
+
+		//result
+		*ptr++ = 0;
+	}
+
+	return 0;
+}
+
+uint32_t nns::hosbinder::IHOSBinderDriver::TransactParcel(IN int32_t _0, IN uint32_t _1, IN uint32_t _2, IN uint8_t * _3, guint _3_size, OUT uint8_t * _4, guint _4_size) {
+	return _TransactParcel(_0, _1, _2, _3, _3_size, _4, _4_size);
+}
+
+uint32_t nns::hosbinder::IHOSBinderDriver::TransactParcelAuto(IN int32_t _0, IN uint32_t _1, IN uint32_t _2, IN uint8_t * _3, guint _3_size, OUT uint8_t * _4, guint _4_size) {
+	return _TransactParcel(_0, _1, _2, _3, _3_size, _4, _4_size);
+}


### PR DESCRIPTION
Gfx support: works with libnx apps but hangs during vsync due to the double-waitsync(manually disabling the second waitsync works with gfx-double-buffering still enabled), while official apps crash at some point during gfx init. This does not include GPU-rendering handling.

Some way of automatically signalling the vsync Waitable would be ideal.

This doesn't include anything for extracting the current framebuf/windowbuf.

Includes various other changes.